### PR TITLE
Amend requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ keras==2.4.*
 tensorflow==2.4.*
 requests
 Pillow
-
-
+pandas
+matplotlib


### PR DESCRIPTION
When attempting to run the
```
# Some common imports
import os
import pandas as pd
import numpy as np
import matplotlib.pyplot as plt
```
python script in Fedora 38 container, I get
```
# python3 script.py
Traceback (most recent call last):
  File "/mnist-tensorflow-model/script.py", line 3, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```
and
```
# python3 script.py
Traceback (most recent call last):
  File "/mnist-tensorflow-model/script.py", line 5, in <module>
    import matplotlib.pyplot as plt
ModuleNotFoundError: No module named 'matplotlib'
```

Adding these two requirements seems to make at least this initial "imports" script pass.

Due to https://github.com/rh-aiservices-bu/mnist-tensorflow-model/issues/1 I'm unable to try this in RHEL 9.2 Jupyter notebook started in DevSandbox per https://developers.redhat.com/learn/openshift-data-science/how-create-tensorflow-model -- that's why I try this at least in Fedora container.