### PR TITLE
Update requirements to match what is already on the TensorFlow 1.2 image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-h5py==2.10.0
-keras==2.4.*
-tensorflow==2.4.*
+h5py==3.7.0
+keras==2.7.*
+tensorflow==2.7.*
 requests
 Pillow
 


### PR DESCRIPTION
Update requirements to match what is already on the TensorFlow 1.2 (based on RHEL 8.7) notebook image in RHODS.